### PR TITLE
Fix complete race condition

### DIFF
--- a/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
+++ b/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import Foundation
+import HeliumLogger
+import LoggerAPI
 
 @testable import CircuitBreaker
 
@@ -21,6 +23,12 @@ class CircuitBreakerTests: XCTestCase {
             ("testTimeoutReset", testTimeoutReset),
             ("testInvocationWrapper", testInvocationWrapper)
         ]
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        HeliumLogger.use(LoggerMessageType.debug)
     }
 
     func sum(a: Int, b: Int) -> Int {
@@ -44,9 +52,9 @@ class CircuitBreakerTests: XCTestCase {
         switch error {
         case BreakerError.timeout:
             timedOut = true
-            print("Timeout")
+            Log.debug("Timeout")
         case BreakerError.fastFail:
-            print("Circuit open")
+            Log.debug("Circuit open")
         }
     }
 


### PR DESCRIPTION
- Fixed race condition for complete function
- Allowed for public access to invocation args
- Updated test cases to use HeliumLogger and LoggerAPI instead of print() - Fixes IBM-Swift/CircuitBreaker#10