### PR TITLE
Fix intermittent test failures

### DIFF
--- a/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
+++ b/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
@@ -123,7 +123,17 @@ class CircuitBreakerTests: XCTestCase {
   }
 
   func time(milliseconds: Int) {
+    #if os(Linux)
     usleep(UInt32(milliseconds * 1000))
+    #elseif swift(>=4.2)
+    RunLoop.current.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: 0.001))
+    let time: Double = Double(milliseconds) / 1000
+    RunLoop.current.run(mode: RunLoop.Mode.default, before: Date(timeIntervalSinceNow: time))
+    #else
+    RunLoop.current.run(mode: .defaultRunLoopMode, before: Date(timeIntervalSinceNow: 0.001))
+    let time: Double = Double(milliseconds) / 1000
+    RunLoop.current.run(mode: .defaultRunLoopMode, before: Date(timeIntervalSinceNow: time))
+    #endif
   }
 
   func timeCtxFunction(invocation: Invocation<(Int), BreakerError>) {

--- a/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
+++ b/Tests/CircuitBreakerTests/CircuitBreakerTests.swift
@@ -664,6 +664,9 @@ class CircuitBreakerTests: XCTestCase {
     // Create one more failure
     breaker.run(commandArgs: (timeout + 50), fallbackArgs: BreakerError.timeout) // timeout
 
+    // Wait for breaker timeout
+    time(milliseconds: timeout + 50)
+    
     XCTAssertEqual(breaker.breakerState, State.open)
     XCTAssertEqual(breaker.breakerStats.successfulResponses, 2)
     XCTAssertEqual(breaker.breakerStats.failedResponses, maxFailures)
@@ -674,7 +677,7 @@ class CircuitBreakerTests: XCTestCase {
     XCTAssertEqual(breaker.breakerStats.rejectedRequests, 1)
 
     // Wait for reset timeout
-    time(milliseconds: resetTimeout)
+    time(milliseconds: resetTimeout + timeout)
 
     XCTAssertEqual(breaker.breakerState, State.halfopen)
 
@@ -687,7 +690,7 @@ class CircuitBreakerTests: XCTestCase {
   // Validate state cycle of the circuit (small rolling window)
   func testSmallRollingWindow() {
     // Breaker should not enter open state after maxFailures is reached because the max number of failures did not occur within the time window specified by rollingWindow.
-    let timeout = 50
+    let timeout = 100
     let resetTimeout = 10000
     let maxFailures = 5
     let rollingWindow = timeout
@@ -705,7 +708,7 @@ class CircuitBreakerTests: XCTestCase {
 
     // Create max failures
     for _ in 1...(maxFailures) {
-      breaker.run(commandArgs: (timeout + 50), fallbackArgs: BreakerError.timeout)
+      breaker.run(commandArgs: (timeout + 100), fallbackArgs: BreakerError.timeout)
       XCTAssertEqual(breaker.breakerState, State.closed)
     }
 

--- a/Tests/CircuitBreakerTests/StatsTests.swift
+++ b/Tests/CircuitBreakerTests/StatsTests.swift
@@ -27,6 +27,8 @@ class StatsTests: XCTestCase {
     return [
       ("testDefaultConstructor", testDefaultConstructor),
       ("testTotalLatency", testTotalLatency),
+      ("testLatencyExecutePercentiles", testLatencyExecutePercentiles),
+      ("testLatencyTotalPercentiles", testLatencyTotalPercentiles),
       ("testTrackTimeouts", testTrackTimeouts),
       ("testTrackSuccessfulResponse", testTrackSuccessfulResponse),
       ("testTrackFailedResponse", testTrackFailedResponse),


### PR DESCRIPTION
This pull request adds some sleeps into the CircuitBreaker tests to allow async tasks to complete before checking for the result