### PR TITLE
Add OSX 10.10 deployment target in podspec file.

### DIFF
--- a/IBMSwiftCircuitBreaker.podspec
+++ b/IBMSwiftCircuitBreaker.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.author     = "IBM"
   s.module_name  = 'CircuitBreaker'
   s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.10"
   s.source   = { :git => "https://github.com/IBM-Swift/CircuitBreaker.git", :tag => s.version }
   s.source_files = "Sources/CircuitBreaker/*.swift"
   s.dependency 'LoggerAPI', '~> 1.7'


### PR DESCRIPTION
This PR adds the OSX deployment target in the `podspec` file, to use CircuitBreaker with CocoaPods dependency management on MacOS. This is required if the Swift Package Manager is not used.