### PR TITLE
Update packages

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
       )
     ],
     dependencies: [
-        .package(url: "https://github.com/Kitura/LoggerAPI.git", .upToNextMajor(from: "1.9.200"))
+        .package(url: "https://github.com/Kitura/LoggerAPI.git", from: "2.0.0")
     ],
     targets: [
       .target(


### PR DESCRIPTION
Swift package is failing to work well (swift package update) as version requirements of cross dependencies are not compatible.